### PR TITLE
Add the ability to generate OSGi metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.maxmind.geoip</groupId>
     <artifactId>geoip-api</artifactId>
     <version>1.2.14-SNAPSHOT</version>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
 
     <parent>
         <groupId>org.sonatype.oss</groupId>
@@ -61,9 +61,20 @@
                     <target>1.6</target>
                 </configuration>
            </plugin>
-       </plugins>
-    </build>
 
+           <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.5.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>com.maxmind.geoip</Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+          </plugins>
+    </build>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
This small pull request add the ability to generate a MANIFEST.MF file when you build the final jar file. This will allow to use the bundle with an OSGi container with no additional efforts (we are currently using it in Liferay within an OSGi container and we would love to have the OSGi metadata out of the box :) )
