### PR TITLE
Decrease target version to 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jdk.version>1.6</jdk.version>
+        <jdk.version>1.5</jdk.version>
         <junit.version>4.11</junit.version>
         <mockito.version>1.9.0</mockito.version>
     </properties>
@@ -57,8 +57,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.5.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.5</source>
+                    <target>1.5</target>
                 </configuration>
            </plugin>
 

--- a/src/main/java/com/maxmind/geoip/LookupService.java
+++ b/src/main/java/com/maxmind/geoip/LookupService.java
@@ -20,8 +20,6 @@
 
 package com.maxmind.geoip;
 
-import static java.lang.System.arraycopy;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -975,7 +973,7 @@ public class LookupService {
             // we have to work around that feature
             // It happens for ::ffff:24.24.24.24
             byte[] t = new byte[16];
-            arraycopy(v6vec, 0, t, 12, 4);
+            System.arraycopy(v6vec, 0, t, 12, 4);
             v6vec = t;
         }
 


### PR DESCRIPTION
We need 1.5 for the annotations. These are primarily used in the tests,
but I don't know if there is much point in trying to support versions
before this.

I also removed an unnecessary static import.