### PR TITLE
Added accessors to the list of all country names and codes

### DIFF
--- a/src/main/java/com/maxmind/geoip/LookupService.java
+++ b/src/main/java/com/maxmind/geoip/LookupService.java
@@ -29,6 +29,8 @@ import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Provides a lookup service for information based on an IP address. The
@@ -405,15 +407,15 @@ public class LookupService {
     /**
      * @return The list of all known country names
      */
-    public String[] getAllCountryNames() {
-        return countryName;
+    public List<String> getAllCountryNames() {
+        return Arrays.asList(Arrays.copyOf(countryName, countryName.length));
     }
     
     /**
      * @return The list of all known country codes
      */
-    public String[] getAllCountryCodes() {
-        return countryCode;
+    public List<String> getAllCountryCodes() {
+        return Arrays.asList(Arrays.copyOf(countryCode, countryCode.length));
     }
     
     /**

--- a/src/main/java/com/maxmind/geoip/LookupService.java
+++ b/src/main/java/com/maxmind/geoip/LookupService.java
@@ -403,6 +403,20 @@ public class LookupService {
     }
 
     /**
+     * @return The list of all known country names
+     */
+    public String[] getAllCountryNames() {
+        return countryName;
+    }
+    
+    /**
+     * @return The list of all known country codes
+     */
+    public String[] getAllCountryCodes() {
+        return countryCode;
+    }
+    
+    /**
      * Returns the country the IP address is in.
      *
      * @param ipAddress


### PR DESCRIPTION
It may be generally useful, in my specific case my application needs to be able to "match" a country name selected by a user with the country name detected by GeoIP. Without access to the list of countries I would have to manually maintain the list separately with the risk of it getting out of sync.