### PR TITLE
squid:S1118, pmd:ImmutableField - Utility classes should not have pub…

### DIFF
--- a/src/main/java/com/maxmind/geoip/Country.java
+++ b/src/main/java/com/maxmind/geoip/Country.java
@@ -27,8 +27,8 @@ package com.maxmind.geoip;
  */
 public class Country {
 
-	private String code;
-	private String name;
+	private final String code;
+	private final String name;
 
 	/**
 	 * Creates a new Country.

--- a/src/main/java/com/maxmind/geoip/DatabaseInfo.java
+++ b/src/main/java/com/maxmind/geoip/DatabaseInfo.java
@@ -69,7 +69,7 @@ public class DatabaseInfo {
 
     private static SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd");
 
-    private String info;
+    private final String info;
 
     /**
      * Creates a new DatabaseInfo object given the database info String.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118, pmd:ImmutableField - Utility classes should not have public constructors, Immutable Field

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118
https://dev.eclipse.org/sonar/coding_rules#q=pmd:ImmutableField

Please let me know if you have any questions.

M-Ezzat