### PR TITLE
squid:S1941 - Variables should not be declared before they are relevant

### DIFF
--- a/src/main/java/com/maxmind/geoip/LookupService.java
+++ b/src/main/java/com/maxmind/geoip/LookupService.java
@@ -298,9 +298,6 @@ public class LookupService {
      *             if an error occurs reading from the database file.
      */
     private synchronized void init() throws IOException {
-        byte[] delim = new byte[3];
-        byte[] buf = new byte[SEGMENT_RECORD_LENGTH];
-
         if (file == null) {
             return;
         }
@@ -308,6 +305,8 @@ public class LookupService {
             mtime = databaseFile.lastModified();
         }
         file.seek(file.length() - 3);
+        byte[] delim = new byte[3];
+        byte[] buf = new byte[SEGMENT_RECORD_LENGTH];
         for (int i = 0; i < STRUCTURE_INFO_MAX_SIZE; i++) {
             file.readFully(delim);
             if (delim[0] == -1 && delim[1] == -1 && delim[2] == -1) {

--- a/src/main/java/com/maxmind/geoip/regionName.java
+++ b/src/main/java/com/maxmind/geoip/regionName.java
@@ -2,11 +2,12 @@ package com.maxmind.geoip;
 // generated automatically from admin/generate_regionName.pl
 public class regionName {
     public static String regionNameByCode(String country_code, String region_code) {
-        String name = null;
-        int region_code2 = -1;
+
         if (region_code == null) { return null; }
         if (region_code.length() == 0) { return null; }
 
+        String name = null;
+        int region_code2 = -1;
         if (    ((region_code.charAt(0) >= 48 ) && ( region_code.charAt(0) < ( 48 + 10 )))
              && ((region_code.charAt(1) >= 48 ) && ( region_code.charAt(1) < ( 48 + 10 )))
         ){

--- a/src/main/java/com/maxmind/geoip/timeZone.java
+++ b/src/main/java/com/maxmind/geoip/timeZone.java
@@ -2,13 +2,13 @@ package com.maxmind.geoip;
 // generated automatically from admin/generate_timeZone.pl
 public class timeZone {
     public static String timeZoneByCountryAndRegion(String country, String region) {
-        String timezone = null;
         if (country == null) {
             return null;
         }
         if (region == null) {
             region = "";
         }
+        String timezone = null;
         if ("AD".equals(country)) {
                 timezone = "Europe/Andorra";
         } else if ("AE".equals(country)) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1941 - Variables should not be declared before they are relevant

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1941

Please let me know if you have any questions.

M-Ezzat