### PR TITLE
refactored LookupService to minimize synchronization for improved multi-threaded performance

### DIFF
--- a/src/main/java/com/maxmind/geoip/LookupService.java
+++ b/src/main/java/com/maxmind/geoip/LookupService.java
@@ -771,7 +771,12 @@ public class LookupService {
     	 */
         private RandomAccessFile file;
         
-        private final ThreadLocal<CharsetDecoder> charsetDecoder = ThreadLocal.withInitial(() -> CHARSET.newDecoder());
+        private final ThreadLocal<CharsetDecoder> charsetDecoder = new ThreadLocal<CharsetDecoder>() {
+        	@Override 
+        	protected CharsetDecoder initialValue() {
+                return CHARSET.newDecoder();
+        	}
+        };
         
         public Database(int dboptions, RandomAccessFile file, DatabaseInfo databaseInfo, byte databaseType, 
         	int[] databaseSegments, int recordLength, byte[] dbbuffer, byte[] index_cache, long mtime) {


### PR DESCRIPTION
### Motivation

This changeset is to minimize synchronization within `LookupService` for improved multi-threaded performance.  For our use case we had performance issues due to performing lookups concurrently from multiple threads, because of contended synchronization.  

Now synchronization is virtually eliminated, and volatile reads/writes are minimized and sometimes not needed at all.  For example in memory-cached mode with reloading disabled, lookups can be performed without any synchronization/volatile.

Even for single-threaded lookups, we saw a performance improvement.  When performing lookup by `long` value, performance improved from about 2.2m to about 3.5m lookups/sec.

### Description of Changes

Because of the structural changes in `LookupService`, it may just be easier to read the old and new code side by side rather than trying to follow a diff. All of the changes are structural, I did not change any of the logic related to reading or decoding data.

The old code had a lot of synchronization in top-level methods, and indeed in various internal methods as well. These were blanket synchronizations that protected various mutable state of the service.

To minimize synchronization I isolated the state which really needs synchronization protection -- (1) state related to reloading or closing the database (only needed if the database is reloadable and/or closeable); (2) the file handle for reading data from disk; (3) the charset decoder.

I had to push the database-related fields down into a new, internal `Database` class to support reloading of a database without always synchronizing. In the normal case we only need a volatile read to get the database instance (and even this can be avoided if the database is not reloadable/closeable). Within this `Database` instance, synchronization is only needed when using the file handle to read data from disk (and this is not needed if the service is being used in memory-cached mode).